### PR TITLE
Fix bug #176, where range(longitude) was equal range(latitude)

### DIFF
--- a/chance.js
+++ b/chance.js
@@ -942,7 +942,6 @@
     };
 
     Chance.prototype.coordinates = function (options) {
-        options = initOptions(options);
         return this.latitude(options) + ', ' + this.longitude(options);
     };
 
@@ -967,7 +966,6 @@
     };
 
     Chance.prototype.geojson = function (options) {
-        options = initOptions(options);
         return this.latitude(options) + ', ' + this.longitude(options) + ', ' + this.altitude(options);
     };
 


### PR DESCRIPTION
Multiple calls to initOptions function prevented default values to affect the option variable's min and max values.

This fixes bug #176.